### PR TITLE
Remove references to mireds, replace with new Kelvin properties

### DIFF
--- a/custom_components/gamma_light/manifest.json
+++ b/custom_components/gamma_light/manifest.json
@@ -7,5 +7,5 @@
   "quality_scale": "silver",
   "iot_class": "calculated",
   "config_flow": true,
-  "version": "1.3.0"
+  "version": "1.4.0"
 }


### PR DESCRIPTION
Old `color_temp` attributes are now deprecated and will be removed in HA 2026.1. Switch over to using the new Kelvin-based attributes.